### PR TITLE
remove unused reference to staging cluster

### DIFF
--- a/cloudbuild.gke-per-test.yaml
+++ b/cloudbuild.gke-per-test.yaml
@@ -142,7 +142,6 @@ options:
   env:
     # location/name of GKE cluster (used by all kubectl commands)
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
 
 timeout:
   3600s


### PR DESCRIPTION
Fixes issue #63 

Removes reference to "staging" cluster, since cloud build config uses the name of newly created cluster instead